### PR TITLE
bug: getAbsoluteUrl throws MalformedURLEx.

### DIFF
--- a/Application/src/main/java/com/daon/identityx/samplefidoapp/RelyingPartyServerComms.java
+++ b/Application/src/main/java/com/daon/identityx/samplefidoapp/RelyingPartyServerComms.java
@@ -236,7 +236,7 @@ public class RelyingPartyServerComms implements IRelyingPartyComms {
         }
     }
 
-    protected String getAbsoluteUrl(String relativeUrl) {
+    protected String getAbsoluteUrl(String relativeUrl) throws MalformedURLException {
         return getBaseUrl() + relativeUrl;
     }
 


### PR DESCRIPTION
com.daon.identityx.samplefidoapp.RelyingPartyServerComms#getAbsoluteUrl needs to throw MalformedURLException as it calls getBaseUrl() that throws that exception (after the previous change, 9 months ago).